### PR TITLE
Refactor character asset updater

### DIFF
--- a/core/utils/update_character_asset_name.py
+++ b/core/utils/update_character_asset_name.py
@@ -1,16 +1,38 @@
 import json
-from utils.constants import emotions, body_actions, screen_mode, characters
+import logging
+from pathlib import Path
 
-with open("utils/mouth_image.json", "r") as json_file:
-    response_json = json.load(json_file)
+from utils.constants import emotions, body_actions, screen_mode
 
-# print(response_json)
+
+LOGGER = logging.getLogger(__name__)
+
+
+def _load_mouth_image_mapping():
+    mouth_image_path = Path(__file__).resolve().parent / "mouth_image.json"
+    try:
+        with mouth_image_path.open("r", encoding="utf-8") as json_file:
+            return json.load(json_file)
+    except FileNotFoundError as exc:
+        raise FileNotFoundError(
+            f"Unable to locate mouth image configuration file at {mouth_image_path}"
+        ) from exc
+    except json.JSONDecodeError as exc:
+        raise ValueError(
+            f"Failed to parse mouth image configuration file at {mouth_image_path}: {exc}"
+        ) from exc
+
+
+response_json = _load_mouth_image_mapping()
+
+
 happy_mouth = ["happy", "content", "sarcasm", "crazy", "evil_laugh", "lust", "silly"]
-print(emotions)
 
 
 def update_assets(data):
-    for each_data in data["words"]:
+    words = data.get("words", [])
+    LOGGER.debug("Updating assets for %d word(s)", len(words))
+    for each_data in words:
         # emotion
         if int(each_data["intensity"]) == 2:
             each_data["emotion_name"] = emotions.get(each_data["emotion"]) + "_2"

--- a/tests/test_update_character_asset_name.py
+++ b/tests/test_update_character_asset_name.py
@@ -1,0 +1,45 @@
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+
+
+def test_update_assets_resolves_relative_paths(tmp_path, monkeypatch):
+    repo_root = Path(__file__).resolve().parents[1]
+    core_path = repo_root / "core"
+    sys.path.insert(0, str(core_path))
+
+    monkeypatch.chdir(tmp_path)
+
+    module_name = "utils.update_character_asset_name"
+    if module_name in sys.modules:
+        del sys.modules[module_name]
+
+    module = importlib.import_module(module_name)
+
+    sample_data = {
+        "words": [
+            {
+                "intensity": 1,
+                "emotion": 1,
+                "character": 1,
+                "screen_mode": 1,
+                "body_action": 1,
+                "phonemes_frame": [{"name": "AA0", "frames": [1, 2, 3]}],
+            }
+        ]
+    }
+
+    updated_data = module.update_assets(sample_data)
+
+    phoneme_details = updated_data["words"][0]["phonemes_frame_details"][0]
+    assert phoneme_details["phoneme"] == "AA0"
+    assert phoneme_details["mouth_name"] == module.response_json["AA0"]["happy"]
+
+
+@pytest.fixture(autouse=True)
+def _cleanup_sys_path():
+    original_sys_path = list(sys.path)
+    yield
+    sys.path[:] = original_sys_path


### PR DESCRIPTION
## Summary
- resolve the mouth image configuration path using the module directory and add defensive error handling
- replace direct printing with structured logging in the asset updater utility
- add a regression test to ensure asset updates work from arbitrary working directories

## Testing
- pytest tests/test_update_character_asset_name.py -vv

------
https://chatgpt.com/codex/tasks/task_b_68ecc9228aa4832fb47a3ab0f0dd7ea1